### PR TITLE
fix dependencies

### DIFF
--- a/google_my_business_v4.gemspec
+++ b/google_my_business_v4.gemspec
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
 require 'date'
-require 'google/apis/core/base_service'
-require 'google/apis/core/json_representation'
-require 'google/apis/core/hashable'
-require 'google/apis/errors'
-
 Gem::Specification.new do |spec|
   spec.name          = 'google_my_business_v4'
   spec.version       = '0'
   spec.authors       = ['Google LLC']
   spec.summary       = 'This gem is a copy of google api v4 my business gem'
   spec.require_paths = ['lib']
+
+  spec.add_dependency 'google-api-client'
 end


### PR DESCRIPTION
Modification du fichier gemspec. Comme la gem fonctionnait sur notre db avec google-api-client, qui a google-api-core comme dépendance, j'ai mis google-api-client comme dépendance. 

### Comment cette PR a été testée
J'ai fait une PR ici https://github.com/Flatlooker/Flatlooker/pull/3101/files qui utilise cette branche comme version de la gem et ai vérifié que la review app buildait correctement